### PR TITLE
[Fixed] #3

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,7 @@ class Proselint(Linter):
 
     """Provides an interface to proselint."""
 
-    syntax = ('html', 'markdown', 'plain text')
+    syntax = ('markdown', 'plain text')
     cmd = 'proselint'
     executable = None
     version_args = '--version'

--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,7 @@ class Proselint(Linter):
 
     """Provides an interface to proselint."""
 
-    syntax = ('markdown', 'plain text')
+    syntax = ('*')
     cmd = 'proselint'
     executable = None
     version_args = '--version'
@@ -28,7 +28,9 @@ class Proselint(Linter):
     multiline = True
     line_col_base = (1, 1)
     tempfile_suffix = 'pltmp'
-    selectors = {}
+    selectors = {
+        '*': 'text.html.markdown, text.plain, text.tex.latex, comment'
+    }
     word_re = None
     defaults = {}
     inline_settings = None


### PR DESCRIPTION
I think, it is would be better to disable linting for HTML, because proselint is linter for text, not for source.

For example, see **#3** issue.

![#3](http://i.imgur.com/9SZ2kC9.png)

Incorrect [**message**](https://github.com/amperser/proselint/blob/127bfe3c7298dfd184799aea5c2a2bb7113ec107/proselint/checks/typography/symbols.py#L81): `Use curly quotes “”, not straight quotes ""`.

Thanks.